### PR TITLE
Feature/1101

### DIFF
--- a/example/App.vue
+++ b/example/App.vue
@@ -243,6 +243,9 @@
         <li>
           <router-link to="/tag">tag</router-link>
         </li>
+        <li>
+          <router-link to="/test">自定义test页面</router-link>
+        </li>
       </ul>
     </nav>
     <!-- <keep-alive>

--- a/example/router/index.js
+++ b/example/router/index.js
@@ -77,6 +77,8 @@ import Schedule from '../views/Schedule.vue'
 
 import DownLoad from '../views/DownLoad.vue'
 
+import Test from '../views/Test.vue'
+
 // const hyh = resolve=>{
 //     import(xxx.js).then(module=>{//import 实现异步加载
 //         resolve(module)
@@ -786,6 +788,11 @@ const router = new Router({
         name: 'Schedule',
         path: '/schedule',
         component: Schedule
+      },
+      {
+        name: 'Test',
+        path: '/test',
+        component: Test,
       }
   ]
 })

--- a/example/views/Page.vue
+++ b/example/views/Page.vue
@@ -36,7 +36,7 @@
       </br>
       <h-table :data="[...tData, ...tData]" :columns="columns" @on-row-click="rowClick"></h-table>
       </br>
-      <h-page :total="totalNum" @on-change="dataChange" show-sizer show-elevator show-total @on-page-size-change="pickerChange" :pageSizeOpts="pageSizeOpts"></h-page>
+      <h-page :total="totalNum" @on-change="dataChange" show-sizer show-elevator show-total @on-page-size-change="pickerChange" :pageSizeOpts="pageSizeOpts" :isLoadAll="true"></h-page>
     </div>
     <h-msg-box v-model="addMsg" width="800" >
       <p slot="header">

--- a/example/views/Table.vue
+++ b/example/views/Table.vue
@@ -184,6 +184,7 @@ export default {
           key: 'name',
           width: 100,
           ellipsis:true,
+          hiddenCol: true,
         },
         {
           title: '姓名1',

--- a/example/views/Test _copy.vue
+++ b/example/views/Test _copy.vue
@@ -1,0 +1,173 @@
+<template>
+<div>
+  
+    <!-- <h-row>
+      <h2>基本用法</h2>
+      <p>设置属性 type 为 date 或 daterange 分别显示选择单日和选择范围类型。<br>
+        设置属性 placement 可以更改选择器出现的方向</p>
+      <h-col span="12">
+      </h-col>
+      <h-col span="12">
+        {{model2}}
+        <h-date-picker v-model="model2" type="daterange" format="yyyy-MM-dd HH:mm"  @on-change="handleChange1"  placement="bottom-end" placeholder="选择日期" valueTypeArr> </h-date-picker>
+       <br><br><br>
+       {{value1}}
+        <h-date-picker :value="value1" format="yyyy年MM月dd日" type="date" placeholder="选择日期" style="width: 200px"></h-date-picker>
+      </h-col>
+    </h-row> -->
+      <h-table :columns="columns" :data="data1" headAlgin="center" border :highlight-row="true" @on-current-change="click1" :loading="loading" bodyAlgin="left">
+        <span slot="loading">我是自定义加载！！！</span>
+      </h-table>
+    
+</div>
+</template>
+<script>
+let jsonData =require('../assets/aa.json');
+export default {
+    data () {
+        return {
+            //  model2:["2018-08-16", "2018-08-23"],
+            model2:"2017-11-13 00:00:00 - 2018-08-23 00:00:00 ",
+            value1: '2016-01-01',
+            model3:"2018-08-16 - 2018-08-24",
+            jsonData:jsonData,
+            columns: [
+              {
+                title: '姓名',
+                key: 'name',
+                width: 100,
+                ellipsis:true,
+                hiddenCol: true,
+              },
+              {
+                title: '姓名1',
+                key: 'name',
+                ellipsis:true,
+              },
+              {
+                title: '年龄',
+                key: 'age',
+                width: 100,
+                ellipsis:true,
+                sortable: true
+              },
+              {
+                title: '年龄1',
+                key: 'age',
+                ellipsis:true,
+                sortable: true
+              },
+              {
+                title: '省份',
+                key: 'province',
+                width: 100,
+                ellipsis:true,
+                sortable: true
+              },{
+                title: '省份1',
+                key: 'province',
+                ellipsis:true
+              },
+              {
+                title: '市区',
+                key: 'city',
+                width: 100,
+                ellipsis:true,
+                sortable: true
+              },{
+                title: '市区1',
+                key: 'city',
+                ellipsis:true
+              },
+              {
+                type: 'text',
+                title: '地址',
+                key: 'address',
+                width: 200,
+                ellipsis:true
+              },{
+                type: 'text',
+                title: '地址1',
+                key: 'address',
+                ellipsis:true
+              },
+              {
+                title: '邮编',
+                key: 'zip',
+                width: 120,
+                ellipsis:true,
+                headerTooltip: true
+              },
+              {
+                title: '邮编1',
+                key: 'zip',
+                ellipsis:true,
+                headerTooltip: true
+              },
+              {
+                title: '操作',
+                key: 'action',
+                render: (h, params) => {
+                  return h('div', [
+                    h('h-button', {
+                      props: {
+                        type: 'info',
+                        size: 'small'
+                      }
+                    }, '查看'),
+                    h('h-button', {
+                      props: {
+                        type: 'text',
+                        size: 'small'
+                      }
+                    }, '编辑')
+                  ]);
+                },
+                ellipsis:true
+              },
+              {
+                title: '邮编1',
+                key: 'zip',
+                ellipsis:true,
+                headerTooltip: true,
+                hiddenCol: true,
+              },
+            ],
+            data1: [
+              {
+                name: 0,
+                age: 18,
+                address: '北京市朝阳区\r芍药居',
+                // _disabled:true,
+                _checked:true,
+              },
+              {
+                name: 0,
+                age: 25,
+                address: '北京市海淀区西二旗'
+              },
+              {
+                name: '李小红',
+                age: 30,
+                address: '上海市浦东新区世纪大道'
+              },
+              {
+                name: '周小伟',
+                age: 26,
+                address: '深圳市南山区深南大道'
+              }
+            ],
+
+
+        }
+    },
+    methods: {
+      handleChange1(val) {
+        // console.log('handleChange---->', val)
+      },
+      click1() {
+
+      },
+    }
+}
+</script>

--- a/example/views/Test.vue
+++ b/example/views/Test.vue
@@ -1,0 +1,38 @@
+<template>
+<div>
+  
+    <h-row>
+      <h2>基本用法</h2>
+      <p>设置属性 type 为 date 或 daterange 分别显示选择单日和选择范围类型。<br>
+        设置属性 placement 可以更改选择器出现的方向</p>
+      <h-col span="12">
+        <!-- <h-date-picker v-model="model1"  format="yyyy-MM-dd" type="date"  :options="options4"   style="width: 200px" @on-clickout="s" :showFormat="true" showToday></h-date-picker>{{model1}} -->
+      </h-col>
+      <h-col span="12">
+        {{model2}}
+        <h-date-picker v-model="model2" type="daterange" format="yyyy-MM-dd HH:mm"   @on-change="handleChange1"  placement="bottom-end" placeholder="选择日期" valueTypeArr> </h-date-picker>
+       <br><br><br>
+       {{model3}}
+        <h-date-picker v-model="model3" type="daterange" @on-change="handleChange1" format="yyyy/MM/dd" showFormat valueTypeArr  placement="bottom-end" placeholder="选择日期"> </h-date-picker>     
+      </h-col>
+    </h-row>
+</div>
+</template>
+<script>
+    export default {
+        data () {
+            return {
+                //  model2:["2018-08-16", "2018-08-23 "],
+                 model2:"2017-11-13 00:00:00 - 2018-08-23 00:00:00 ",
+                 model3:["2018-08-16", "2018-08-24"],
+                //  model3:"2018-08-16 - 2018-08-24",
+
+            }
+        },
+        methods: {
+          handleChange1() {
+
+          }
+        }
+    }
+</script>

--- a/example/views/Test.vue
+++ b/example/views/Test.vue
@@ -13,7 +13,7 @@
         <h-date-picker v-model="model2" type="daterange" format="yyyy-MM-dd HH:mm"   @on-change="handleChange1"  placement="bottom-end" placeholder="选择日期" valueTypeArr> </h-date-picker>
        <br><br><br>
        {{model3}}
-        <h-date-picker v-model="model3" type="daterange" @on-change="handleChange1" format="yyyy/MM/dd" showFormat valueTypeArr  placement="bottom-end" placeholder="选择日期"> </h-date-picker>     
+        <h-date-picker v-model="model3" type="date" @on-change="handleChange1" format="yyyy/MM/dd" showFormat valueTypeArr  placement="bottom-end" placeholder="选择日期"> </h-date-picker>     
       </h-col>
     </h-row>
 </div>

--- a/example/views/Test.vue
+++ b/example/views/Test.vue
@@ -1,39 +1,752 @@
 <template>
-<div>
-  
-    <h-row>
-      <h2>基本用法</h2>
-      <p>设置属性 type 为 date 或 daterange 分别显示选择单日和选择范围类型。<br>
-        设置属性 placement 可以更改选择器出现的方向</p>
-      <h-col span="12">
-        <!-- <h-date-picker v-model="model1"  format="yyyy-MM-dd" type="date"  :options="options4"   style="width: 200px" @on-clickout="s" :showFormat="true" showToday></h-date-picker>{{model1}} -->
-      </h-col>
-      <h-col span="12">
-        {{model2}}
-        <h-date-picker v-model="model2" type="daterange" format="yyyy-MM-dd HH:mm"   @on-change="handleChange1"  placement="bottom-end" placeholder="选择日期" valueTypeArr> </h-date-picker>
-       <br><br><br>
-       {{value1}}
-        <h-date-picker :value="value1" format="yyyy年MM月dd日" type="date" placeholder="选择日期" style="width: 200px"></h-date-picker>
-        <!-- <h-date-picker :value="model3" type="date"  placeholder="选择日期"> </h-date-picker>      -->
-      </h-col>
-    </h-row>
-</div>
+  <div class="factorTest">
+    <h2>修改模式要素1</h2>
+    <div>
+      <button @click="submitFormData">提交测试</button>
+      <button @click="popPage">弹出测试</button>
+      <button @click="gotoPage">跳转测试</button>
+      <button @click="closePage">关闭测试</button>
+      <button @click="activePage">激活主页测试</button>
+      <button @click="refreshPage">刷新测试</button>
+    </div>
+     <h-table class="tables" rowSelectOnly  border :columns="columns2" :data="data1"></h-table>
+  <!-- <h-table :columns="columns" :data="data1" headAlgin="center" border :highlight-row="true" @on-current-change="click1" :loading="loading" bodyAlgin="left">
+        <span slot="loading">我是自定义加载！！！</span>
+      </h-table> -->
+    
+    
+  </div>
 </template>
 <script>
-    export default {
-        data () {
-            return {
-                 model2:["2018-08-16", "2018-08-23"],
-                //  model2:"2017-11-13 00:00:00 - 2018-08-23 00:00:00 ",
-                 value1: '2016-01-01',
-                 model3:"2018-08-16 - 2018-08-24",
+const ItemCol = 6 ;
+export default {
+  name: "trust_base_biz_factorTest",
+  data() {
+    return {
+      columns2: [
+				{
+					type: "selection",
+					width: 60,
+					align: "center"
+				},
+				{
+          title: "姓名",
+          width: 60,
+					key: "name"
+				},
+				{
+          title: "年龄",
+          // width: 60,
+					key: "age"
+				},
+				{
+          // hiddenCol:true,
+					title: "地址",
+					key: "address"
+				}
+			],
+			data1: [
+				{
+					name: "王小明",
+					age: 18,
+					address: "北京市朝阳区芍药居"
+				},
+				{
+					name: "张小刚",
+					age: 25,
+					address: "北京市海淀区西二旗"
+				}
+			],
+      factors3: {
+        has_panel: true,
+        cols: 12,
+        labelWidth: 140,
+        query_mode: "query_update",
+          factor_type_list: [
+          {
+            factor_type_name: "下拉框",
+            factor_type_code: "combox1",
+            factors: [
+              {
+                init_value: "",
+                factor_type_code: "combox1",
+                is_can_update: true,
+                copy_from_out: "",
+                rule_id: "r1",
+                factor_desc: "要素类型5",
+                field_type: "5",
+                is_can_view: true,
+                from_edit_table: false,
+                factor_name: "要素5下拉框",
+                factor_code: "combox1_5_1",
+                factor_value: null,
+                isneedreview: false,
+                ext_config: {
+                  required:true,
+                  cols: 6,
+                  hasGroup: true,
+                  items: [
+                    {
+                      label: "中國",
+                      items: [
+                        {
+                          code: "beijing",
+                          text: "北京市"
+                        },
+                        {
+                          code: "shanghai",
+                          text: "上海市"
+                        },
+                        {
+                          code: "shenzhen",
+                          text: "深圳市"
+                        },
+                        {
+                          code: "hangzhou",
+                          text: "杭州市"
+                        },
+                        {
+                          code: "nanjing",
+                          text: "南京市"
+                        },
+                        {
+                          code: "chongqing",
+                          text: "重庆市"
+                        }
+                      ]
+                    },
+                    {
+                      label: "American",
+                      items: [
+                        {
+                          code: "newyork",
+                          text: "紐約"
+                        },
+                        {
+                          code: "Chicago",
+                          text: "芝加哥"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                init_value: "",
+                factor_type_code: "combox1",
+                is_can_update: true,
+                copy_from_out: "",
+                rule_id: "r1",
+                factor_desc: "要素类型10",
+                field_type: "10",
+                is_can_view: true,
+                from_edit_table: false,
+                factor_name: "要素10多选下拉框",
+                factor_code: "combox1_10_1",
+                factor_value: null,
+                isneedreview: false,
+                ext_config: {
+                  cols: 6,
+                  hasGroup: true,
+                  items: [
+                    {
+                      label: "中國",
+                      items: [
+                        {
+                          code: "beijing",
+                          text: "北京市"
+                        },
+                        {
+                          code: "shanghai",
+                          text: "上海市"
+                        },
+                        {
+                          code: "shenzhen",
+                          text: "深圳市"
+                        },
+                        {
+                          code: "hangzhou",
+                          text: "杭州市"
+                        },
+                        {
+                          code: "nanjing",
+                          text: "南京市"
+                        },
+                        {
+                          code: "chongqing",
+                          text: "重庆市"
+                        }
+                      ]
+                    },
+                    {
+                      label: "American",
+                      items: [
+                        {
+                          code: "newyork",
+                          text: "紐約"
+                        },
+                        {
+                          code: "Chicago",
+                          text: "芝加哥"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+           factor_type_name: "测试组件",
+           factor_type_code: "demo",
+            factors: [
+              {
+                init_value: "",
+                is_can_update: true,
+                copy_from_out: "",
+                rule_id: "r1",
+                factor_desc: "要素类型1",
+                field_type: "1",
+                is_can_view: true,
+                from_edit_table: false,
+                factor_name: "要素1普通文本",
+                factor_code: "input1_1_1",
+                factor_value: "回填文本值已输入",
+                isneedreview: false,
+                ext_config: {
+                  cols: ItemCol,
+                  validRules: [
+                    {
+                      test: {},
+                      message: "不全是字母",
+                      trigger: "blur"
+                    }
+                  ],
+                  required: true
+                }
+              },
+              {
+                init_value: "",
+                is_can_update: true,
+                copy_from_out: "",
+                rule_id: "require_rule_test|disable_rule_test|visible_rule_test|changeFactorLabel_rule_test|setCompVisibleByTypename_rule_test|exp_rule_test|tipRule_rule_test|confirmRule_rule_test",
+                factor_desc: "要素类型2",
+                field_type: "2",
+                is_can_view: true,
+                from_edit_table: false,
+                factor_name: "要素2数字录入",
+                factor_code: "input1_2_1",
+                factor_value: "1234",
+                isneedreview: false,
+                ext_config: {
+                  cols: ItemCol,
+                  tip:{
+                    content:"kkkkkk",
+                    placement:"right-start",
+                    icon:{position:"right"}
+                  }
+                }
+              },
+              {
+                init_value: "",
+                is_can_update: true,
+                copy_from_out: "",
+                rule_id: "r1",
+                factor_desc: "要素类型4",
+                field_type: "4",
+                is_can_view: true,
+                from_edit_table: false,
+                factor_name: "要素4日期录入",
+                factor_code: "date1_4_1",
+                factor_value: "2019-09-04",
+                isneedreview: false,
+                ext_config: {
+                  cols: ItemCol
+                }
+              },
+              {
+                init_value: "",
+                is_can_update: true,
+                copy_from_out: "",
+                rule_id: "r1",
+                factor_desc: "要素类型16",
+                field_type: "16",
+                is_can_view: true,
+                from_edit_table: false,
+                factor_name: "要素16金额录入",
+                factor_code: "typefield1_16_1",
+                factor_value: "",
+                isneedreview: false,
+                ext_config: {
+                  cols: ItemCol
+                }
+              },
+              {
+                init_value: "",
+                is_can_update: true,
+                copy_from_out: "",
+                rule_id: "tipRule_rule_test2",
+                factor_desc: "要素类型18",
+                field_type: "18",
+                is_can_view: true,
+                from_edit_table: false,
+                factor_name: "要素18金额录入",
+                factor_code: "typefield1_18_1",
+                factor_value: "",
+                isneedreview: false,
+                ext_config: {
+                  cols: ItemCol
+                }
+              },
+              {
+                init_value: "",
+                is_can_update: true,
+                copy_from_out: "",
+                rule_id: "tipRule_rule_test3",
+                factor_desc: "要素类型3",
+                field_type: "3",
+                is_can_view: true,
+                from_edit_table: false,
+                factor_name: "要素3文本域录入",
+                factor_code: "input1_3_1",
+                factor_value: "sss",
+                isneedreview: false,
+                ext_config: {
+                  cols: 6
+                }
+              },
+              {
+                is_can_update: true,
+                field_type: "6",
+                factor_name: "6:数据字典",
+                factor_code: "combox1_6_1",
+                factor_value: null,
+                ext_config: {
+                  cols: ItemCol,
+                  dictName: "BIZ_AUTH_TYPE"
+                }
+              },
+              {
+                is_can_update: true,
+                field_type: "9",
+                factor_name: "9:数据字典多选",
+                factor_code: "combox1_9_1",
+                factor_value: null,
+                ext_config: {
+                  cols: ItemCol,
+                  dictName: "BIZ_AUTH_TYPE"
+                }
+              },
+              {
+                is_can_update: true,
+                field_type: "17",
+                factor_name: "17:数据字典模糊搜索多选",
+                factor_code: "combox1_17_1",
+                factor_value: null,
+                ext_config: {
+                  cols: ItemCol,
+                  dictName: "PROJECT_PHASE"
+                }
+              },
+              {
+                is_can_update: true,
+                field_type: "14",
+                factor_name: "14:單选默认支持模糊搜索",
+                factor_code: "combox1_1ItemCol_1",
+                factor_value: null,
+                ext_config: {
+                  cols: ItemCol,
+                  hasGroup: true,
+                  items: [
+                    {
+                      label: "中國",
+                      items: [
+                        {
+                          code: "beijing",
+                          text: "北京市"
+                        },
+                        {
+                          code: "shanghai",
+                          text: "上海市"
+                        },
+                        {
+                          code: "shenzhen",
+                          text: "深圳市"
+                        },
+                        {
+                          code: "hangzhou",
+                          text: "杭州市"
+                        },
+                        {
+                          code: "nanjing",
+                          text: "南京市"
+                        },
+                        {
+                          code: "chongqing",
+                          text: "重庆市"
+                        }
+                      ]
+                    },
+                    {
+                      label: "American",
+                      items: [
+                        {
+                          code: "newyork",
+                          text: "紐約"
+                        },
+                        {
+                          code: "Chicago",
+                          text: "芝加哥"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                is_can_update: true,
+                field_type: "15",
+                factor_name: "15:多选默认支持模糊搜索",
+                factor_code: "combox1_15_1",
+                factor_value: null,
+                ext_config: {
+                  cols: ItemCol,
+                  hasGroup: true,
+                  items: [
+                    {
+                      label: "中國",
+                      items: [
+                        {
+                          code: "beijing",
+                          text: "北京市"
+                        },
+                        {
+                          code: "shanghai",
+                          text: "上海市"
+                        },
+                        {
+                          code: "shenzhen",
+                          text: "深圳市"
+                        },
+                        {
+                          code: "hangzhou",
+                          text: "杭州市"
+                        },
+                        {
+                          code: "nanjing",
+                          text: "南京市"
+                        },
+                        {
+                          code: "chongqing",
+                          text: "重庆市"
+                        }
+                      ]
+                    },
+                    {
+                      label: "American",
+                      items: [
+                        {
+                          code: "newyork",
+                          text: "紐約"
+                        },
+                        {
+                          code: "Chicago",
+                          text: "芝加哥"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                is_can_update: false,
+                field_type: "31",
+                factor_name: "31:分组组件",
+                factor_code: "filedgroup",
+                factor_value:{
+                  tree:'',
+                  input1:'',
+                },
+                ext_config:{
+                  cols: ItemCol,
+                  leftType:'t-base-select-tree',
+                  rightType:'t-base-input',
+                  leftField:{
+                    data:[
+                      {
+                        title: 'parent',
+                        id: '1-0',
+                        children: [
+                          {
+                            title: 'child1',
+                            id: '1-1',
+                            children: [
+                              {
+                                title: 'child1-1-1',
+                                id: '1-1-1'
+                              },
+                              {
+                                title: 'child1-1-2',
+                                id: '1-1-2'
+                              }
+                            ]
+                          },
+                          {
+                            title: 'child2',
+                            id: '1-2',
+                            children: []
+                          }
+                        ]
+                      }
+                    ],
+                    hiddenLabel:true,
+                    checkprop:"tree",
+                    required:true,
+                  },
+                  rightField:{
+                    labelWidth:0,
+                    hiddenLabel:true,
+                    checkprop:"input1",
+                    required:true,
+                  },
+                }
+              },
+              {
+                is_can_update: false,
+                field_type: "28",
+                factor_name: "28:日期组组件",
+                factor_code: "Dates",
+                factor_value:{
+                  data1:'',
+                  data2:'',
+                  data3:''
+                },
+                ext_config:{
+                  cols: ItemCol,
+                  leftType:'t-base-date',
+                  rightType:'t-base-date',
+                  sort:true,
+                  leftField:{
+                    hiddenLabel:true,
+                    checkprop:"data1",
+                    required:true,
+                  },
+                  rightField:{
+                    labelWidth:0,
+                    hiddenLabel:true,
+                    checkprop:"data2",
+                    required:true,
+                  },
+                  sortField:{
+                    checkprop:"data3",
+                  }
+                }
+              },
+              {
+                  is_can_update: false,
+                  field_type: "20",
+                  factor_name: "20:隐藏域",
+                  factor_code: "input1_20_1",
+                  factor_value: "sss",
+                  ext_config: {
+                      cols: ItemCol
+                  }
+              },
+              {
+                  is_can_update: false,
+                  field_type: "33",
+                  factor_name: "33:级联组件",
+                  factor_code: "tab_select_1",
+                  factor_value: "",
+                  ext_config: {
+                      hiddenLabel:true,
+                      cols: ItemCol,
+                      data:[
+                          {
+                              value: 'beijing',
+                              label: '北京',
+                              children: [
+                                  {
+                                      value: 'gugong',
+                                      label: '故宫'
+                                  },
+                                  {
+                                      value: 'tiantan',
+                                      label: '天坛'
+                                  },
+                                  {
+                                      value: 'wangfujing',
+                                      label: '王府井'
+                                  }
+                              ]
+                          },
+                          {
+                              value: 'jiangsu',
+                              label: '江苏',
+                              children: [
+                                  {
+                                      value: 'nanjing',
+                                      label: '南京',
+                                      children: [
+                                          {
+                                              value: 'fuzimiao',
+                                              label: '夫子庙',
+                                          }
+                                      ]
+                                  },
+                                  {
+                                      value: 'suzhou',
+                                      label: '苏州',
+                                      children: [
+                                          {
+                                              value: 'zhuozhengyuan',
+                                              label: '拙政园',
+                                          },
+                                          {
+                                              value: 'shizilin',
+                                              label: '狮子林',
+                                          }
+                                      ]
+                                  }
+                              ],
+                          }
+                      ],
+                      pathvalue:false,
+                      reqParams:{
+                          url:"",
+                          params:{value:1,key:2}
+                      },
+                      required:false,
+                  }
+              },
+              {
+                  is_can_update: false,
+                  field_type: "39",
+                  factor_name: "39:时间区间",
+                  factor_code: "input1_39_1",
+                  factor_value: "20190904 - 20190905",
+                  ext_config: {
+                    format:"yyyyMMdd",
+                      cols: ItemCol
+                  }
+              },
+              {
+                  is_can_update: false,
+                  field_type: "30",
+                  factor_name: "30:下拉自定义URL页面",
+                  factor_code: "cascader",
+                  factor_value: "22222222222",
+                  ext_config: {
+                      cols: ItemCol,
+                      exterior:false,
+                      url:"views/bizViews/factor/form",
+                      required:false,
+                      hiddenLabel:true
+                  }
+              },
+               {
+                  is_can_update: false,
+                  field_type: "34",
+                  factor_name: "34:富文本",
+                  factor_code: "base-editor",
+                  factor_value: {content:"22222222222"},
+                  ext_config: {
+                  }
+              }
+            ]
+          },
+              {
+                  factor_type_name: "文档上传",
+                  factor_type_code: "textUpload",
+                  factors:[{
+                      is_can_update: false,
+                      field_type: "21",
+                      factor_name: "自定义页面2",
+                      factor_code: "dyncpage1",
+                      factor_value: { stringInput: "sasa" },
+                      ext_config: {
+                          path_props:{app_name:"BASE",route_id:"trust_base_biz_singleUploadView"},
+                          required: true,
+                          hiddenLabel:true
+                      }
+                  }]
+              }
+        ],
+          factor_rule_list: [
+          {
+              is_not_exe_rule: "0",
+              fun_name: "setCompVisibleByTypename",
+              rule_name: "分类隐藏",
+              temp_code: null,
+              fun_args: "'下拉框',[input1_2_1]!='12345678'",
+              rule_id: "setCompVisibleByTypename_rule_test",
+              event_type: "on-change",
+              is_use: "1",
+              is_init_exe: "2"
+          },
+          
+        ]
+      }
+    };
+  },
+  created() {
+    // this.$on('do-factor-ext-fc',this.doFactorExtFc)
+  },
+  methods: {
+    doFactorExtFc(value) {
+      console.log(value);
+    },
+    doFactorExtFc2(value) {
+      console.log(value);
+    },
+    deleteFirstFactor(){
+        this.$refs.factorComp.deleteFactor(this.$refs.factorComp.dataPool.factorData[0]["factors"][0]);
+    },
+    changeFactorName(){
+        this.$refs.factorComp["changeFactorName"]({"factor_name":"hhhh","factor_code":this.$refs.factorComp.dataPool.factorData[0]["factors"][0]["factor_code"]})
+    },
+    copyFactor(){
+        let f = this.$refs.factorComp.dataPool.factorData[0]["factors"][0];
+        f.factor_type_name = "sss" ;
+        this.$refs.factorComp["copyFactor"]({"factor":f})
+    },
+    submitFormData(){
+       let res = this.$refs.factorForm.getAllFactorData(true,true)
+       console.log(res)
+    },
+    popPage(){
 
-            }
-        },
-        methods: {
-          handleChange1() {
-
-          }
-        }
+    },
+    gotoPage(){
+      let parm = {};
+      let tabObj = {
+          tabId: "basecompTest"+(Math.random()+""),
+          tabName: "基础组件测试",
+          tabUrl: "/test/basecompTest",
+          routeId: "trust_base_biz_basecompTest",
+          propInfo: parm,
+          configInfo: {isKeepAlive:true}
+      };
+      this.$TBaseTab.addSysTab(tabObj);
+    },
+    closePage(){
+        this.$TBaseTab.close();
+    },
+    activePage(){
+        this.$TBaseTab.activate("mainIndex");
+    },
+    refreshPage(){
+        this.$TBaseTab.refresh();
     }
+  }
+};
 </script>
+<style>
+.factorTest h2 {
+  margin: 10px;
+  color: #0058ff;
+}
+.tables{
+  width: 500px;
+}
+</style>

--- a/example/views/Test.vue
+++ b/example/views/Test.vue
@@ -12,8 +12,9 @@
         {{model2}}
         <h-date-picker v-model="model2" type="daterange" format="yyyy-MM-dd HH:mm"   @on-change="handleChange1"  placement="bottom-end" placeholder="选择日期" valueTypeArr> </h-date-picker>
        <br><br><br>
-       {{model3}}
-        <h-date-picker v-model="model3" type="date" @on-change="handleChange1" format="yyyy/MM/dd" showFormat valueTypeArr  placement="bottom-end" placeholder="选择日期"> </h-date-picker>     
+       {{value1}}
+        <h-date-picker :value="value1" format="yyyy年MM月dd日" type="date" placeholder="选择日期" style="width: 200px"></h-date-picker>
+        <!-- <h-date-picker :value="model3" type="date"  placeholder="选择日期"> </h-date-picker>      -->
       </h-col>
     </h-row>
 </div>
@@ -22,10 +23,10 @@
     export default {
         data () {
             return {
-                //  model2:["2018-08-16", "2018-08-23 "],
-                 model2:"2017-11-13 00:00:00 - 2018-08-23 00:00:00 ",
-                 model3:["2018-08-16", "2018-08-24"],
-                //  model3:"2018-08-16 - 2018-08-24",
+                 model2:["2018-08-16", "2018-08-23"],
+                //  model2:"2017-11-13 00:00:00 - 2018-08-23 00:00:00 ",
+                 value1: '2016-01-01',
+                 model3:"2018-08-16 - 2018-08-24",
 
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4301,8 +4301,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4323,14 +4322,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4345,20 +4342,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4475,8 +4469,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4488,7 +4481,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4503,7 +4495,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4511,14 +4502,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4537,7 +4526,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4618,8 +4606,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4631,7 +4618,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4717,8 +4703,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4754,7 +4739,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4774,7 +4758,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4818,14 +4801,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/components/DatePicker/panel/Date/date-range.vue
+++ b/src/components/DatePicker/panel/Date/date-range.vue
@@ -350,11 +350,9 @@ export default {
       }
     },
     showYearPicker(panel) {
-      // this.currentView = 'year'
       this[`${panel}PickerTable`] = 'year-table'
     },
     showMonthPicker(panel) {
-      // this.currentView = 'month'
       this[`${panel}PickerTable`] = 'month-table'
     },
     handlePreSelection(panel, value) {

--- a/src/components/DatePicker/panel/Date/date-range.vue
+++ b/src/components/DatePicker/panel/Date/date-range.vue
@@ -306,11 +306,11 @@ export default {
       }
     },
     prevYear(panel) {
-      const increment = this.currentView === 'year' ? -10 : -1
+      const increment = (this.currentView === 'year' || this[`${panel}PickerTable`] === 'year-table')? -10 : -1
       this.changePanelDate(panel, 'FullYear', increment)
     },
     nextYear(panel) {
-      const increment = this.currentView === 'year' ? 10 : 1
+      let increment = (this.currentView === 'year' || this[`${panel}PickerTable`] === 'year-table') ? 10 : 1
       this.changePanelDate(panel, 'FullYear', increment)
     },
     prevMonth(panel) {
@@ -350,9 +350,11 @@ export default {
       }
     },
     showYearPicker(panel) {
+      // this.currentView = 'year'
       this[`${panel}PickerTable`] = 'year-table'
     },
     showMonthPicker(panel) {
+      // this.currentView = 'month'
       this[`${panel}PickerTable`] = 'month-table'
     },
     handlePreSelection(panel, value) {

--- a/src/components/DatePicker/picker.vue
+++ b/src/components/DatePicker/picker.vue
@@ -288,6 +288,7 @@ export default {
       if (this.multiple) {
         return this.internalValue.slice()
       } else {
+        if (isEmptyArray(this.internalValue)) return []
         // const isRange = this.type.includes('range');
         const isRange = this.type.indexOf('range') > -1 ? true : false
         let val = this.internalValue.map(date =>
@@ -300,8 +301,9 @@ export default {
     publicStringValue() {
       const { formatDate, publicVModelValue, type } = this
       if (type.match(/^time/)) return publicVModelValue
+      const arr = publicVModelValue.map(formatDate)
       return Array.isArray(publicVModelValue)
-        ? publicVModelValue.map(formatDate)
+        ? isEmptyArray(arr) ? [] : arr
         : formatDate(publicVModelValue)
     },
     //    opened() {

--- a/src/components/DatePicker/picker.vue
+++ b/src/components/DatePicker/picker.vue
@@ -251,12 +251,21 @@ export default {
     }
   },
   data() {
+    let value = this.value; 
     const isRange = this.type.indexOf('range') > -1 ? true : false
+    if (typeof this.value === 'string' ) value = this.value.split(' - ')
+
     const emptyArray = isRange ? [null, null] : [null]
-    let initialValue = isEmptyArray((isRange ? this.value : [this.value]) || [])
+    let initialValue = isEmptyArray((isRange ? value : [value]) || [])
       ? emptyArray
-      : this.parseDate(this.value)
-    if (this.name == 'splicePanel') initialValue = this.parseDate(this.value)
+      : this.parseDate(value)
+    if (this.name == 'splicePanel') initialValue = this.parseDate(value)
+
+    // const emptyArray = isRange ? [null, null] : [null]
+    // let initialValue = isEmptyArray((isRange ? this.value : [this.value]) || [])
+    //   ? emptyArray
+    //   : this.parseDate(this.value)
+    // if (this.name == 'splicePanel') initialValue = this.parseDate(this.value)
     return {
       prefixCls: prefixCls,
       showClose: false,

--- a/src/components/DatePicker/picker.vue
+++ b/src/components/DatePicker/picker.vue
@@ -253,7 +253,7 @@ export default {
   data() {
     let value = this.value; 
     const isRange = this.type.indexOf('range') > -1 ? true : false
-    if (typeof this.value === 'string' ) value = this.value.split(' - ')
+    if (typeof this.value === 'string' && this.type.includes('range') ) value = this.value.split(' - ')
 
     const emptyArray = isRange ? [null, null] : [null]
     let initialValue = isEmptyArray((isRange ? value : [value]) || [])

--- a/src/components/Page/Options.vue
+++ b/src/components/Page/Options.vue
@@ -4,7 +4,7 @@
     <div v-if="showSizer" :class="sizerClasses">
       <h-select v-model="currentPageSize" :size="size" :placement="placement" @on-change="changeSize" :clearable="false">
         <h-option v-for="item in pageSizeOpts" :key="item" :value="item" style="text-align:center;">{{ item }} {{ t('i.page.page') }}</h-option>
-        <h-option :value="-1">{{t('i.page.showAll')}}</h-option>
+        <h-option v-if="isLoadAll" :value="-1">{{t('i.page.showAll')}}</h-option>
       </h-select>
     </div>
     <div v-if="showCustom&&!showSizer" :class="ElevatorClasses">
@@ -50,6 +50,7 @@
             showCustom:Boolean,
             showSizerLabel: Boolean,
             showReload:Boolean,
+            isLoadAll: Boolean,
         },
         data () {
             return {

--- a/src/components/Page/Page.vue
+++ b/src/components/Page/Page.vue
@@ -105,6 +105,7 @@
         :show-sizer="showSizer"
         :page-size="currentPageSize"
         :page-size-opts="pageSizeOpts"
+        :is-load-all="isLoadAll"
         :placement="placement"
         :show-elevator="showElevator"
         :show-custom="showCustom"
@@ -202,6 +203,10 @@
       showReload:{
         type: Boolean,
         default: false
+      },
+      isLoadAll: {
+        type: Boolean,
+        default: false,
       }
     },
     data () {


### PR DESCRIPTION
1.修复date组件daterange时间选择器点击事件不能直接快速翻至上一页的年份
2. 新增page组件isLoadAll属性，添加加载全部的选项
3. 修复Date组件on-change属性，选择范围为空时，由['','']—>[]
4. 新增Date组件，type含有range时，（daterange、datetimerange、monthrange）初始化格式支持字符串，数组两种格式。e.g(2019-11-13 - 2019-12-16，["2019-11-13'', "2019-12-16"])